### PR TITLE
Replace Slack notifications with Telegram for lead magnet

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,8 +3,9 @@
 # Run this SQL command in Supabase SQL Editor:
 # SELECT vault.create_secret('your_resend_api_key', 'resend_api_key', 'Resend API key for sending welcome emails');
 
-# Slack Configuration
-SLACK_WEBHOOK_URL=your-slack-webhook-url
+# Telegram Configuration
+TELEGRAM_BOT_TOKEN=your-telegram-bot-token
+TELEGRAM_CHAT_ID=your-telegram-chat-id
 
 # Supabase Configuration
 SUPABASE_URL=your-supabase-url

--- a/backend/src/config/validateEnv.ts
+++ b/backend/src/config/validateEnv.ts
@@ -48,9 +48,12 @@ const ENV_VAR_SCHEMA: EnvVarConfig[] = [
     validateUrl: true,
   },
   {
-    name: 'SLACK_WEBHOOK_URL',
+    name: 'TELEGRAM_BOT_TOKEN',
     required: false,
-    validateUrl: true,
+  },
+  {
+    name: 'TELEGRAM_CHAT_ID',
+    required: false,
   },
 ];
 

--- a/backend/src/routes/subscriptions.ts
+++ b/backend/src/routes/subscriptions.ts
@@ -50,23 +50,29 @@ router.post('/', async (req: Request, res: Response) => {
       return ResponseHelper.badRequest(res, error.message);
     }
 
-    // Ping Slack (Lead Magnet Notification)
+    // Ping Telegram (Lead Magnet Notification)
     try {
-      const SLACK_WEBHOOK_URL = process.env.SLACK_WEBHOOK_URL;
-      if (SLACK_WEBHOOK_URL) {
-        await fetch(SLACK_WEBHOOK_URL, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            text: `🚀 *New lead joined the waitlist!*\n📧 Email: ${emailInput}\n📅 Date: ${new Date().toLocaleString()}`,
-          }),
-        });
+      const TELEGRAM_BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
+      const TELEGRAM_CHAT_ID = process.env.TELEGRAM_CHAT_ID;
+      if (TELEGRAM_BOT_TOKEN && TELEGRAM_CHAT_ID) {
+        await fetch(
+          `https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              chat_id: TELEGRAM_CHAT_ID,
+              text: `🚀 *New lead joined the waitlist!*\n📧 Email: ${emailInput}\n📅 Date: ${new Date().toLocaleString()}`,
+              parse_mode: 'Markdown',
+            }),
+          }
+        );
       }
-    } catch (slackError) {
-      // We don't want to fail the subscription if Slack notification fails
+    } catch (telegramError) {
+      // We don't want to fail the subscription if Telegram notification fails
       console.error(
-        '[Subscriptions] Failed to send Slack notification:',
-        slackError
+        '[Subscriptions] Failed to send Telegram notification:',
+        telegramError
       );
     }
 


### PR DESCRIPTION
## Summary
Migrated the lead magnet notification system from Slack to Telegram, updating the subscription endpoint to use Telegram Bot API instead of Slack webhooks.

## Key Changes
- **Notification Service**: Replaced Slack webhook integration with Telegram Bot API in the subscriptions route
  - Changed from `SLACK_WEBHOOK_URL` to `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` environment variables
  - Updated API endpoint to use Telegram's `sendMessage` method
  - Added `parse_mode: 'Markdown'` to preserve message formatting

- **Environment Configuration**: Updated validation schema and example environment file
  - Removed `SLACK_WEBHOOK_URL` validation (which included URL validation)
  - Added `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` as separate optional configuration variables
  - Updated `.env.example` with new Telegram configuration template

- **Error Handling**: Updated error logging to reference Telegram instead of Slack while maintaining the same non-blocking behavior (subscription succeeds even if notification fails)

## Implementation Details
- The notification message format remains unchanged, preserving the same user-friendly output
- Both Telegram configuration variables are optional, allowing graceful degradation if not configured
- The change maintains backward compatibility in terms of subscription functionality - notifications are still optional and don't affect the core subscription flow

https://claude.ai/code/session_01969GbNynhQ6BdwyfJFEkEK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updated Features**
  * Subscription confirmations are now sent via Telegram instead of Slack.
  * Configuration updated to use Telegram bot credentials rather than Slack webhook URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->